### PR TITLE
Remove extra parameter in calls to too-many?

### DIFF
--- a/pastiche.scm
+++ b/pastiche.scm
@@ -110,9 +110,9 @@
            (hits (length (filter spam-token? tokens))))
       (and (not (zero? 100%))
            (< spam-ratio (/ hits 100%)))))
-  (or (too-many? nick spam-token? 0)
-      (too-many? title spam-token? 0)
-      (too-many? paste spam-token? 0.2)))
+  (or (too-many? nick 0)
+      (too-many? title 0)
+      (too-many? paste 0.2)))
 
 
 ;;;


### PR DESCRIPTION
213fb2f25 started calling `too-many?` with an extra argument, but
that procedure only accepts two.