### PR TITLE
Fix linkage spec position

### DIFF
--- a/pastiche.egg
+++ b/pastiche.egg
@@ -5,4 +5,4 @@
  (category web)
  (dependencies awful awful-sql-de-lite simple-sha1 intarweb html-parser colorize miscmacros utf8)
  (test-dependencies srfi-1 srfi-13 http-client test server-test sxpath)
- (components (extension pastiche) (linkage static)))
+ (components (extension pastiche (linkage static))))


### PR DESCRIPTION
This fixes the warning issues by chicken-install:

Warning (/home/gahr/.cache/chicken-install/pastiche/pastiche.egg): property `linkage' invalid or in wrong context (component)